### PR TITLE
feature-002-entidades-y-dtos

### DIFF
--- a/src/main/java/com/equipo5/backend/model/Booking.java
+++ b/src/main/java/com/equipo5/backend/model/Booking.java
@@ -10,7 +10,6 @@ Establecer relaciones @ManyToOne hacia Pet, Service y User (owner).
 import jakarta.persistence.*;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import org.springframework.data.annotation.Id;
 
 import java.time.LocalDate;
 

--- a/src/main/java/com/equipo5/backend/model/Pet.java
+++ b/src/main/java/com/equipo5/backend/model/Pet.java
@@ -6,7 +6,6 @@ import lombok.NoArgsConstructor;
 
 import java.util.ArrayList;
 import java.util.List;
-import org.springframework.data.annotation.Id;
 
 @Entity
 @Data

--- a/src/main/java/com/equipo5/backend/model/ServiceEntity.java
+++ b/src/main/java/com/equipo5/backend/model/ServiceEntity.java
@@ -3,7 +3,6 @@ package com.equipo5.backend.model;
 import jakarta.persistence.*;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import org.springframework.data.annotation.Id;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/com/equipo5/backend/model/UserEntity.java
+++ b/src/main/java/com/equipo5/backend/model/UserEntity.java
@@ -32,10 +32,10 @@ public class UserEntity {
     private Role rol;
 
     @OneToMany(mappedBy = "owner", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<Pet> pets;
+    private List<Pet> pets = new ArrayList<>();
 
     @OneToMany(mappedBy = "owners", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<ServiceEntity> services;
+    private List<ServiceEntity> services = new ArrayList<>();
 
     @OneToMany(mappedBy = "owners", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Booking> bookings = new ArrayList<>();

--- a/src/main/java/com/equipo5/backend/model/UserEntity.java
+++ b/src/main/java/com/equipo5/backend/model/UserEntity.java
@@ -6,7 +6,6 @@ import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import org.springframework.data.annotation.Id;
 
 import java.time.Instant;
 import java.util.ArrayList;

--- a/src/test/java/com/equipo5/backend/model/BookingTest.java
+++ b/src/test/java/com/equipo5/backend/model/BookingTest.java
@@ -1,0 +1,36 @@
+package com.equipo5.backend.model;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class BookingTest {
+
+    @Test
+    void testBookingFieldsAndRelations() {
+
+        UserEntity user = new UserEntity();
+        Pet pet = new Pet();
+        ServiceEntity service = new ServiceEntity();
+
+        Booking booking = new Booking();
+        booking.setStartTime(LocalDate.of(2025, 8, 26));
+        booking.setEndTime(LocalDate.of(2025, 8, 27));
+        booking.setStatus(true);
+
+        booking.setOwners(user);
+        booking.setPets(pet);
+        booking.setServices(service);
+
+        assertEquals(LocalDate.of(2025, 8, 26), booking.getStartTime());
+        assertEquals(LocalDate.of(2025, 8, 27), booking.getEndTime());
+        assertTrue(booking.getStatus());
+
+        assertEquals(user, booking.getOwners());
+        assertEquals(pet, booking.getPets());
+        assertEquals(service, booking.getServices());
+    }
+
+}

--- a/src/test/java/com/equipo5/backend/model/PetTest.java
+++ b/src/test/java/com/equipo5/backend/model/PetTest.java
@@ -1,0 +1,69 @@
+package com.equipo5.backend.model;
+
+import jakarta.validation.*;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PetTest {
+
+    @Test
+    void testPetFieldsAndRelations() {
+        // Crear objetos relacionados
+        UserEntity owner = new UserEntity();
+
+        // Crear lista de bookings
+        List<Booking> bookings = new ArrayList<>();
+        Booking booking1 = new Booking();
+        Booking booking2 = new Booking();
+        bookings.add(booking1);
+        bookings.add(booking2);
+
+        // Crear la entidad Pet y asignar campos
+        Pet pet = new Pet();
+        pet.setName("Fido");
+        pet.setSpecies("Dog");
+        pet.setBreed("Labrador");
+        pet.setOwner(owner);
+        pet.setBookings(bookings);
+
+        // Assert campos simples
+        assertEquals("Fido", pet.getName());
+        assertEquals("Dog", pet.getSpecies());
+        assertEquals("Labrador", pet.getBreed());
+
+        // Assert relaciones
+        assertEquals(owner, pet.getOwner());
+        assertEquals(2, pet.getBookings().size());
+        assertTrue(pet.getBookings().contains(booking1));
+        assertTrue(pet.getBookings().contains(booking2));
+    }
+
+    // Este test demuestra que estamos permitiendo entidades con campos null dado que no hay validaciones!
+    // Recomendable agregar a TODAS las entidades para evitar futuros errores de integridad.
+
+    // Ejemplos:
+    // @NotBlank(message = "Pet name cannot be blank")
+    // @NotNull(message = "Pet must have an owner")
+    // Esto Nos permite usar @Valid antes de persistir para verificas que este correcta.
+    @Test
+    void testPetValidation() {
+        Pet pet = new Pet();
+        pet.setName(""); // inválido
+        pet.setSpecies(null); // inválido
+        pet.setOwner(null); // inválido
+
+        ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+        Validator validator = factory.getValidator();
+        Set<ConstraintViolation<Pet>> violations = validator.validate(pet);
+
+        assertFalse(violations.isEmpty());
+        assertTrue(violations.stream().anyMatch(v -> v.getPropertyPath().toString().equals("name")));
+        assertTrue(violations.stream().anyMatch(v -> v.getPropertyPath().toString().equals("species")));
+        assertTrue(violations.stream().anyMatch(v -> v.getPropertyPath().toString().equals("owner")));
+    }
+}

--- a/src/test/java/com/equipo5/backend/model/ServiceEntityTest.java
+++ b/src/test/java/com/equipo5/backend/model/ServiceEntityTest.java
@@ -1,0 +1,35 @@
+package com.equipo5.backend.model;
+
+import com.equipo5.backend.model.enums.Role;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ServiceEntityTest {
+
+    @Test
+    void testServiceEntityFieldsAndRelations() {
+
+        UserEntity user = new UserEntity();
+        user.setName("John Doe");
+        user.setEmail("john@example.com");
+        user.setPassword("12345");
+        user.setRol(Role.ADMINISTRATOR);
+
+        Booking booking = new Booking();
+
+        ServiceEntity service = new ServiceEntity();
+        service.setPrice(11.11);
+        service.setDescription("test");
+        service.setName("Service John Doe");
+        service.setOwners(user);
+        service.getBookings().add(booking);
+
+        assertTrue(service.getBookings().contains(booking));
+        assertEquals(service.getOwners(), user);
+        assertEquals("Service John Doe", service.getName());
+        assertEquals("test", service.getDescription());
+        assertEquals(11.11, service.getPrice());
+    }
+
+}

--- a/src/test/java/com/equipo5/backend/model/UserEntityTest.java
+++ b/src/test/java/com/equipo5/backend/model/UserEntityTest.java
@@ -1,0 +1,81 @@
+package com.equipo5.backend.model;
+
+import jakarta.validation.*;
+import org.junit.jupiter.api.Test;
+import com.equipo5.backend.model.enums.Role;
+
+import java.time.Instant;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class UserEntityTest {
+
+    @Test
+    void testUserEntitySettersAndGetters() {
+        UserEntity user = new UserEntity();
+        user.setName("John Doe");
+        user.setEmail("john@example.com");
+        user.setPassword("12345");
+        user.setRol(Role.ADMINISTRATOR);
+
+        assertEquals("John Doe", user.getName());
+        assertEquals("john@example.com", user.getEmail());
+        assertEquals("12345", user.getPassword());
+        assertEquals(Role.ADMINISTRATOR, user.getRol());
+    }
+
+    //Test de manipulacion de Listas, no hay Persistencia ni Cascada
+    @Test
+    void testAddPetsServicesBookings() {
+        UserEntity user = new UserEntity();
+
+        Pet pet = new Pet();
+        user.getPets().add(pet);
+        assertTrue(user.getPets().contains(pet));
+
+        ServiceEntity service = new ServiceEntity();
+        user.getServices().add(service);
+        assertTrue(user.getServices().contains(service));
+
+        Booking booking = new Booking();
+        user.getBookings().add(booking);
+        assertTrue(user.getBookings().contains(booking));
+    }
+
+    @Test
+    void testPrePersistSetsCreatedAndUpdated() {
+        UserEntity user = new UserEntity();
+        user.prePersist();
+
+        assertNotNull(user.getCreatedAt());
+        assertNotNull(user.getUpdatedAt());
+        assertEquals(user.getCreatedAt(), user.getUpdatedAt());
+    }
+
+    @Test
+    void testPreUpdateSetsUpdated() throws InterruptedException {
+        UserEntity user = new UserEntity();
+        user.prePersist();
+
+        Instant beforeUpdate = user.getUpdatedAt();
+        Thread.sleep(10); // asegurar que pasa un tiempo
+        user.preUpdate();
+
+        assertTrue(user.getUpdatedAt().isAfter(beforeUpdate));
+    }
+
+    // Validacion: debe fallar si no llamamos a los metodos prePersist y preUpdate
+    @Test
+    void testValidationFailsWithoutPrePersist() {
+        UserEntity user = new UserEntity();
+        ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+        Validator validator = factory.getValidator();
+
+        Set<ConstraintViolation<UserEntity>> violations = validator.validate(user);
+
+        assertFalse(violations.isEmpty());
+        assertTrue(violations.stream().anyMatch(v -> v.getPropertyPath().toString().equals("createdAt")));
+        assertTrue(violations.stream().anyMatch(v -> v.getPropertyPath().toString().equals("updatedAt")));
+    }
+}

--- a/src/test/java/com/equipo5/backend/model/dtos/UserRequestDTOTest.java
+++ b/src/test/java/com/equipo5/backend/model/dtos/UserRequestDTOTest.java
@@ -1,0 +1,104 @@
+package com.equipo5.backend.model.dtos;
+
+import com.equipo5.backend.model.dtos.request.UserRequestDTO;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
+import jakarta.validation.*;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UserRequestDTOTest {
+
+    private Validator validator;
+
+    @BeforeEach
+    void setUp() {
+        ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+        validator = factory.getValidator();
+    }
+
+    @Test
+    void shouldPassValidationWhenAllFieldsAreValid() {
+        var dto = new UserRequestDTO("John", "john@mail.com", "secret");
+        Set<ConstraintViolation<UserRequestDTO>> violations = validator.validate(dto);
+        assertThat(violations).isEmpty();
+    }
+
+    @Test
+    void shouldFailValidationWhenNameIsBlank() {
+        var dto = new UserRequestDTO(" ", "john@mail.com", "secret");
+        Set<ConstraintViolation<UserRequestDTO>> violations = validator.validate(dto);
+        assertThat(violations).extracting("message")
+                .contains("Incomplete attribute: 'name'");
+    }
+
+    @Test
+    void shouldFailValidationWhenEmailIsBlank() {
+        var dto = new UserRequestDTO("John", "", "secret");
+        Set<ConstraintViolation<UserRequestDTO>> violations = validator.validate(dto);
+        assertThat(violations).extracting("message")
+                .contains("Incomplete attribute: 'email'");
+    }
+
+    @Test
+    void shouldFailValidationWhenPasswordIsBlank() {
+        var dto = new UserRequestDTO("John", "john@mail.com", " ");
+        Set<ConstraintViolation<UserRequestDTO>> violations = validator.validate(dto);
+        assertThat(violations).extracting("message")
+                .contains("Incomplete attribute: 'password'");
+    }
+
+    @Test
+    void shouldFailValidationWhenAnyFieldIsNull() {
+        var dto1 = new UserRequestDTO("John", "john@mail.com", null);
+        var dto2 = new UserRequestDTO("John", null, "123");
+        var dto3 = new UserRequestDTO(null, "john@mail.com", "123");
+        Set<ConstraintViolation<UserRequestDTO>> violations1 = validator.validate(dto1);
+        Set<ConstraintViolation<UserRequestDTO>> violations2 = validator.validate(dto2);
+        Set<ConstraintViolation<UserRequestDTO>> violations3 = validator.validate(dto3);
+        assertThat(violations1).extracting("message")
+                .contains("Incomplete attribute: 'password'");
+        assertThat(violations2).extracting("message")
+                .contains("Incomplete attribute: 'email'");
+        assertThat(violations3).extracting("message")
+                .contains("Incomplete attribute: 'name'");
+    }
+
+    @Test
+    void shouldCreateUserRequestDTO() {
+        // Arrange
+        String name = "John Doe";
+        String email = "john.doe@example.com";
+        String password = "secret123";
+
+        // Act
+        UserRequestDTO dto = new UserRequestDTO(name, email, password);
+
+        // Assert
+        assertThat(dto.name()).isEqualTo(name);
+        assertThat(dto.email()).isEqualTo(email);
+        assertThat(dto.password()).isEqualTo(password);
+    }
+
+    @Test
+    void shouldCompareDTOsByValues() {
+        UserRequestDTO dto1 = new UserRequestDTO("Jane", "jane@example.com", "pass");
+        UserRequestDTO dto2 = new UserRequestDTO("Jane", "jane@example.com", "pass");
+
+        assertThat(dto1).isEqualTo(dto2);
+        assertThat(dto1.hashCode()).isEqualTo(dto2.hashCode());
+    }
+
+    @Test
+    void shouldGenerateToString() {
+        UserRequestDTO dto = new UserRequestDTO("Alice", "alice@example.com", "pass");
+
+        String result = dto.toString();
+
+        assertThat(result).contains("Alice");
+        assertThat(result).contains("alice@example.com");
+    }
+}


### PR DESCRIPTION
Se corrigieron las anotaciones @Id en las entidades JPA. Spring no arranca porque Hibernate no reconoce ese @Id. Tratemos de ejecutar localmente antes de subir, así evitamos que se rompa el entorno 🚀

Anteriormente se estaba utilizando la anotación de Spring Data:
import org.springframework.data.annotation.Id;

Esta anotación corresponde a repositorios como MongoDB y no es válida para entidades JPA/Hibernate.

Ahora se reemplazó por la anotación correcta de Jakarta Persistence:
import jakarta.persistence.Id;
